### PR TITLE
Disabled the X-Powered-By header

### DIFF
--- a/lolisafe.js
+++ b/lolisafe.js
@@ -15,6 +15,7 @@ fs.existsSync('./' + config.uploads.folder) || fs.mkdirSync('./' + config.upload
 fs.existsSync('./' + config.uploads.folder + '/thumbs') || fs.mkdirSync('./' + config.uploads.folder + '/thumbs')
 
 safe.set('trust proxy', 1)
+safe.disable('x-powered-by')
 
 let limiter = new RateLimit({ windowMs: 5000, max: 2 })
 safe.use('/api/login/', limiter)


### PR DESCRIPTION
>  Attackers can use this header (which is enabled by default) to detect apps running Express and then launch specifically-targeted attacks.
 - [Express Best Security Practices](https://expressjs.com/en/advanced/best-practice-security.html)